### PR TITLE
Parse USCIS processing times from AILA pdfs

### DIFF
--- a/uscis-processing-time/aila-report-parser.py
+++ b/uscis-processing-time/aila-report-parser.py
@@ -1,43 +1,109 @@
 #!/usr/bin/env python3
 
+import glob
+import re
+import textract
+import csv
+import dateparser
+
 DOWNLOAD_DIR = 'aila-processing-time-reports/'
 
-#ysc_17-03-14.pdf
-#filename = DOWNLOAD_DIR+'vsc_14-12-23.pdf'
-filename = DOWNLOAD_DIR+'tsc_09-01-27.pdf'
+files = glob.glob(DOWNLOAD_DIR+"*.pdf")
+
+r_form = '[A-Z][-­]\d\d\w*'
+r_date = '(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w* \d\d?,\s(?:199|200|201)\d'
+r_duration = '\d+.?\d* (?:Months|Years|Days)'
+
+def posted_date(text, basename):
+    matches = re.findall(f'(?:as of:?|Posted) ({r_date})', text)
+
+    date_str = ''
+    if len(matches) > 0:
+        date_str = matches[0]
+    else: # if the date isn't found in the text, extract it from the filename
+        match = re.match('.*_(\d\d-\d\d-\d\d)', basename)
+        if match:
+            group = match.group(1)
+            if group[0] in ['0', '1']:
+                date_str = '20'+group
+            else:
+                date_str = '19'+group
+
+    return date_str
+
+def sanitize(text):
+    #starts = ['Processing Cases As Of Date:', 'Processing\s?Timeframe']
+    #ends = ['Contact Us']
+
+    removals = [f'Last Updated: {r_date}', f'Form {r_form}']
+
+    sanitized = text
+    for removal in removals:
+        sanitized = re.sub(removal, 'XXXXXXXX_REMOVED_XXXXXXXX', sanitized)
+
+    return sanitized
+
+def parse_table(text):
+    proc_line_regex = re.compile(f"(({r_form})\s.*?(?:\s)({r_date}|{r_duration}))", re.MULTILINE | re.DOTALL)
+
+    lines = []
+    for match in proc_line_regex.findall(text):
+        lines.append({'form': match[1], 'time': match[2], 'capture_size': len(match[0])})
+
+    return lines
+
+def read_pdf(filename):
+    try:
+        return textract.process(filename).decode('utf-8')
+    except KeyboardInterrupt:
+        raise
+    except:
+        print('Exception processing', filename)
+        return ''
+
+with open('aila-pdf-times.csv', mode='w') as csv_file:
+    csv_writer = csv.writer(csv_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+
+    csv_writer.writerow(['form', 'wait_days', 'ahead_of_schedule', 'processing_date', 'file', 'posted_date', 'capture_size'])
+
+    i = 0
+    for filename in [DOWNLOAD_DIR+'tsc_13-04-03.pdf']:
+    #for filename in files:
+        i += 1
+        if i % 100 == 1:
+            print("Parsing pdf %d of %d"%(i, len(files)))
+
+        basename = re.match('.*/(.*).pdf', filename).group(1)
+
+        text = read_pdf(filename)
+
+        raw_posted = posted_date(text, basename)
+        posted = dateparser.parse(raw_posted)
+        now = dateparser.parse('now')
+
+        #print('posted', posted)
+
+        sanitized = sanitize(text)
+
+        lines = parse_table(sanitized)
+
+        for line in lines:
+            normed_date = dateparser.parse(line['time'])
+
+            is_relative = re.match(r_duration, line['time']) != None
+            if is_relative:
+                time_delta = (now - normed_date)
+                date_res = posted - time_delta
+                wait_time = time_delta
+            else:
+                date_res = normed_date
+                wait_time = posted - normed_date
 
 
-import re
+            #print('date', date_res, is_relative, line['time'])
 
-#import tabula
-#df = tabula.read_pdf(filename)
-#df[['Form', 'Processing Cases As Of Date:']]
+            csv_writer.writerow([line['form'], wait_time.days, is_relative, date_res.strftime("%Y-%m-%d"), basename, posted.strftime("%Y-%m-%d"), line['capture_size']])
 
-import textract
-text = textract.process(filename).decode('utf-8')
-
-# works for ysc_17-03-14.pdf
-#proc_line_regex = re.compile(r"((I[-­]\d\d\w*)\s+(?:Petition|Application).*?(?:199|200|201)\d)", re.MULTILINE | re.DOTALL)
-
-# works mostly for ysc_17-03-14.pdf and vsc_14-12-23.pdf, but screws up first row
-#proc_line_regex = re.compile(r"((I[-­]\d\d\w*)\s+(?:Consideration|Petition|Application).*?(?:199\d|200\d|201\d|Months))", re.MULTILINE | re.DOTALL)
-
-# works for ysc_17-03-14.pdf and vsc_14-12-23.pdf
-#form = '[A-Z][-­]\d\d\w*'
-#date = '(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w* \d\d?, (?:199|200|201)\d'
-#duration = '\d+.?\d* (?:Months|Years|Days)'
-#
-#proc_line_regex = re.compile(f"(({form})\s.*?\s({date}|{duration}))", re.MULTILINE | re.DOTALL)
-
-form = '[A-Z][-­]\d\d\w*'
-date = '(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w* \d\d?, (?:199|200|201)\d'
-duration = '\d+.?\d* (?:Months|Years|Days)'
-
-proc_line_regex = re.compile(f"(({form})\s.*?\s({date}|{duration}))", re.MULTILINE | re.DOTALL)
-
-[print(len(x[0]), " | ", x[1], " | ", x[2], ) for x in proc_line_regex.findall(text)]
-
-
-print(text)
+print('Done parsing pdfs')
 
 

--- a/uscis-processing-time/aila-report-parser.py
+++ b/uscis-processing-time/aila-report-parser.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+DOWNLOAD_DIR = 'aila-processing-time-reports/'
+
+#ysc_17-03-14.pdf
+#filename = DOWNLOAD_DIR+'vsc_14-12-23.pdf'
+filename = DOWNLOAD_DIR+'tsc_09-01-27.pdf'
+
+
+import re
+
+#import tabula
+#df = tabula.read_pdf(filename)
+#df[['Form', 'Processing Cases As Of Date:']]
+
+import textract
+text = textract.process(filename).decode('utf-8')
+
+# works for ysc_17-03-14.pdf
+#proc_line_regex = re.compile(r"((I[-­]\d\d\w*)\s+(?:Petition|Application).*?(?:199|200|201)\d)", re.MULTILINE | re.DOTALL)
+
+# works mostly for ysc_17-03-14.pdf and vsc_14-12-23.pdf, but screws up first row
+#proc_line_regex = re.compile(r"((I[-­]\d\d\w*)\s+(?:Consideration|Petition|Application).*?(?:199\d|200\d|201\d|Months))", re.MULTILINE | re.DOTALL)
+
+# works for ysc_17-03-14.pdf and vsc_14-12-23.pdf
+#form = '[A-Z][-­]\d\d\w*'
+#date = '(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w* \d\d?, (?:199|200|201)\d'
+#duration = '\d+.?\d* (?:Months|Years|Days)'
+#
+#proc_line_regex = re.compile(f"(({form})\s.*?\s({date}|{duration}))", re.MULTILINE | re.DOTALL)
+
+form = '[A-Z][-­]\d\d\w*'
+date = '(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w* \d\d?, (?:199|200|201)\d'
+duration = '\d+.?\d* (?:Months|Years|Days)'
+
+proc_line_regex = re.compile(f"(({form})\s.*?\s({date}|{duration}))", re.MULTILINE | re.DOTALL)
+
+[print(len(x[0]), " | ", x[1], " | ", x[2], ) for x in proc_line_regex.findall(text)]
+
+
+print(text)
+
+

--- a/uscis-processing-time/aila-report-parser.py
+++ b/uscis-processing-time/aila-report-parser.py
@@ -44,11 +44,17 @@ def sanitize(text):
     return sanitized
 
 def parse_table(text):
-    proc_line_regex = re.compile(f"(({r_form})\s.*?(?:\s)({r_date}|{r_duration}))", re.MULTILINE | re.DOTALL)
+    proc_line_regex = re.compile(f"(^({r_form})(?:\n\n(.*?)\n\n(.*?)\n\n|.*?)({r_date}|{r_duration}))", re.MULTILINE | re.DOTALL)
 
     lines = []
     for match in proc_line_regex.findall(text):
-        lines.append({'form': match[1], 'time': match[2], 'capture_size': len(match[0])})
+        #print("11111111111111111111111111111")
+        #print(match[2])
+        #print("22222222222222222222222222222")
+        #print(match[3])
+        #print("33333333333333333333333333333")
+
+        lines.append({'form': match[1], 'title': re.sub('\n', ' ', match[2]), 'classification': re.sub('\n', ' ', match[3]), 'time': match[-1], 'capture_size': len(match[0])})
 
     return lines
 
@@ -64,11 +70,11 @@ def read_pdf(filename):
 with open('aila-pdf-times.csv', mode='w') as csv_file:
     csv_writer = csv.writer(csv_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
 
-    csv_writer.writerow(['form', 'wait_days', 'ahead_of_schedule', 'processing_date', 'file', 'posted_date', 'capture_size'])
+    csv_writer.writerow(['form', 'title', 'classification' 'wait_days', 'ahead_of_schedule', 'processing_date', 'file', 'posted_date', 'capture_size'])
 
     i = 0
-    for filename in [DOWNLOAD_DIR+'tsc_13-04-03.pdf']:
-    #for filename in files:
+    #for filename in [DOWNLOAD_DIR+'tsc_13-04-03.pdf']:
+    for filename in files[0:100]:
         i += 1
         if i % 100 == 1:
             print("Parsing pdf %d of %d"%(i, len(files)))
@@ -99,10 +105,9 @@ with open('aila-pdf-times.csv', mode='w') as csv_file:
                 date_res = normed_date
                 wait_time = posted - normed_date
 
-
             #print('date', date_res, is_relative, line['time'])
 
-            csv_writer.writerow([line['form'], wait_time.days, is_relative, date_res.strftime("%Y-%m-%d"), basename, posted.strftime("%Y-%m-%d"), line['capture_size']])
+            csv_writer.writerow([line['form'], line['title'], line['classification'], wait_time.days, is_relative, date_res.strftime("%Y-%m-%d"), basename, posted.strftime("%Y-%m-%d"), line['capture_size']])
 
 print('Done parsing pdfs')
 

--- a/uscis-processing-time/aila-report-parser.py
+++ b/uscis-processing-time/aila-report-parser.py
@@ -48,12 +48,6 @@ def parse_table(text):
 
     lines = []
     for match in proc_line_regex.findall(text):
-        #print("11111111111111111111111111111")
-        #print(match[2])
-        #print("22222222222222222222222222222")
-        #print(match[3])
-        #print("33333333333333333333333333333")
-
         lines.append({'form': match[1], 'title': re.sub('\n', ' ', match[2]), 'classification': re.sub('\n', ' ', match[3]), 'time': match[-1], 'capture_size': len(match[0])})
 
     return lines
@@ -70,24 +64,22 @@ def read_pdf(filename):
 with open('aila-pdf-times.csv', mode='w') as csv_file:
     csv_writer = csv.writer(csv_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
 
-    csv_writer.writerow(['form', 'title', 'classification' 'wait_days', 'ahead_of_schedule', 'processing_date', 'file', 'posted_date', 'capture_size'])
+    csv_writer.writerow(['form', 'title', 'classification', 'wait_days', 'ahead_of_schedule', 'processing_date', 'posted_date', 'office', 'file', 'capture_size'])
 
     i = 0
-    #for filename in [DOWNLOAD_DIR+'tsc_13-04-03.pdf']:
-    for filename in files[0:100]:
+    for filename in files:
         i += 1
         if i % 100 == 1:
             print("Parsing pdf %d of %d"%(i, len(files)))
 
         basename = re.match('.*/(.*).pdf', filename).group(1)
+        office = re.match('.*/([^_]*)_[^/]*.pdf', filename).group(1)
 
         text = read_pdf(filename)
 
         raw_posted = posted_date(text, basename)
         posted = dateparser.parse(raw_posted)
         now = dateparser.parse('now')
-
-        #print('posted', posted)
 
         sanitized = sanitize(text)
 
@@ -105,10 +97,15 @@ with open('aila-pdf-times.csv', mode='w') as csv_file:
                 date_res = normed_date
                 wait_time = posted - normed_date
 
-            #print('date', date_res, is_relative, line['time'])
-
-            csv_writer.writerow([line['form'], line['title'], line['classification'], wait_time.days, is_relative, date_res.strftime("%Y-%m-%d"), basename, posted.strftime("%Y-%m-%d"), line['capture_size']])
+            csv_writer.writerow([line['form'],
+                                 line['title'],
+                                 line['classification'],
+                                 wait_time.days,
+                                 is_relative,
+                                 date_res.strftime("%Y-%m-%d"),
+                                 posted.strftime("%Y-%m-%d"),
+                                 office,
+                                 basename,
+                                 line['capture_size']])
 
 print('Done parsing pdfs')
-
-


### PR DESCRIPTION
Automatically extract processing times from AILA processing time pdfs.

This script uses textract to extract raw text from the pdfs, then applies a series of heuristic regexes to remove spurious data and extract target times/dates.

Known issues include:
 - The calculation of days in a month, which varies based on the day the script is executed. 
 - Textract somestimes extracts text lines from the pdf in an unexpected order which leads to missing or inaccurate dates/times